### PR TITLE
Define url to load local resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,6 @@ If field limit == 1, this will return only the single attached post ID.
 
 ### 1.0.0
 * Initial commit
+
+### 1.1.0-sebask
+* Added a function which enables usage of CMB2 Field Post Search Ajax from a location other then the Wordpress Plugins folder.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,6 @@ If field limit == 1, this will return only the single attached post ID.
 
 ### 1.1.0-sebask
 * Added a function which enables usage of CMB2 Field Post Search Ajax from a location other then the Wordpress Plugins folder.
+
+### 1.1.1-sebask
+* Fixed a minor bug which caused the use of an undefined constant.

--- a/cmb-field-post-search-ajax.php
+++ b/cmb-field-post-search-ajax.php
@@ -4,7 +4,7 @@ Plugin Name: CMB2 Field Type: Post Search Ajax
 Plugin URI: https://github.com/alexis-magina/cmb2-field-post-search-ajax
 GitHub Plugin URI: https://github.com/alexis-magina/cmb2-field-post-search-ajax
 Description: CMB2 field type to attach posts to each others.
-Version: 1.0.0
+Version: 1.1.0-sebask
 Author: Magina
 Author URI: http://magina.fr/
 License: GPLv2+
@@ -18,7 +18,7 @@ class MAG_CMB2_Field_Post_Search_Ajax {
 	/**
 	 * Current version number
 	 */
-	const VERSION = '1.0.0';
+	const VERSION = '1.1.0-sebask';
 
 	/**
 	 * The url which is used to load local resources

--- a/cmb-field-post-search-ajax.php
+++ b/cmb-field-post-search-ajax.php
@@ -4,7 +4,7 @@ Plugin Name: CMB2 Field Type: Post Search Ajax
 Plugin URI: https://github.com/alexis-magina/cmb2-field-post-search-ajax
 GitHub Plugin URI: https://github.com/alexis-magina/cmb2-field-post-search-ajax
 Description: CMB2 field type to attach posts to each others.
-Version: 1.1.0-sebask
+Version: 1.1.1-sebask
 Author: Magina
 Author URI: http://magina.fr/
 License: GPLv2+
@@ -18,7 +18,7 @@ class MAG_CMB2_Field_Post_Search_Ajax {
 	/**
 	 * Current version number
 	 */
-	const VERSION = '1.1.0-sebask';
+	const VERSION = '1.1.1-sebask';
 
 	/**
 	 * The url which is used to load local resources
@@ -118,7 +118,7 @@ class MAG_CMB2_Field_Post_Search_Ajax {
 		/**
 		 * Filter the CMB2 FPSA location url
 		 */
-		self::$url = trailingslashit( apply_filters( 'cmb2_fpsa_url', $cmb2_fpsa_url, VERSION ) );
+		self::$url = trailingslashit( apply_filters( 'cmb2_fpsa_url', $cmb2_fpsa_url, self::VERSION ) );
 	
 		return self::$url . $path;
 	}

--- a/cmb-field-post-search-ajax.php
+++ b/cmb-field-post-search-ajax.php
@@ -21,6 +21,11 @@ class MAG_CMB2_Field_Post_Search_Ajax {
 	const VERSION = '1.0.0';
 
 	/**
+	 * The url which is used to load local resources
+	 */
+	protected static $url = '';
+	
+	/**
 	 * Initialize the plugin by hooking into CMB2
 	 */
 	public function __construct() {
@@ -92,18 +97,45 @@ class MAG_CMB2_Field_Post_Search_Ajax {
 	}
 
 	/**
+	 * Defines the url which is used to load local resources. Based on, and uses, 
+	 * the CMB2_Utils class from the CMB2 library.
+	 */
+	public static function url( $path = '' ) {
+		if ( self::$url ) {
+			return self::$url . $path;
+		}
+		
+		/**
+		 * Set the variable cmb2_fpsa_dir
+		 */
+		$cmb2_fpsa_dir = trailingslashit( dirname( __FILE__ ) );
+		
+		/**
+		 * Use CMB2_Utils to gather the url from cmb2_fpsa_dir
+		 */	
+		$cmb2_fpsa_url = CMB2_Utils::get_url_from_dir( $cmb2_fpsa_dir );
+	
+		/**
+		 * Filter the CMB2 FPSA location url
+		 */
+		self::$url = trailingslashit( apply_filters( 'cmb2_fpsa_url', $cmb2_fpsa_url, VERSION ) );
+	
+		return self::$url . $path;
+	}
+	
+	/**
 	 * Enqueue scripts and styles
 	 */
 	public function setup_admin_scripts() {
 		
-		wp_register_script( 'jquery-autocomplete', plugins_url( 'js/jquery.autocomplete.min.js', __FILE__ ), array( 'jquery' ), self::VERSION );
-		wp_register_script( 'mag-post-search-ajax', plugins_url( 'js/mag-post-search-ajax.js', __FILE__ ), array( 'jquery', 'jquery-autocomplete', 'jquery-ui-sortable' ), self::VERSION );
+		wp_register_script( 'jquery-autocomplete', self::url( 'js/jquery.autocomplete.min.js' ), array( 'jquery' ), self::VERSION );
+		wp_register_script( 'mag-post-search-ajax', self::url( 'js/mag-post-search-ajax.js' ), array( 'jquery', 'jquery-autocomplete', 'jquery-ui-sortable' ), self::VERSION );
 		wp_localize_script( 'mag-post-search-ajax', 'psa', array(
 			'ajaxurl' 	=> admin_url( 'admin-ajax.php' ),
 			'nonce'		=> wp_create_nonce( 'mag_cmb_post_search_ajax_get_results' )
 		) ); 
 		wp_enqueue_script( 'mag-post-search-ajax' );
-		wp_enqueue_style( 'mag-post-search-ajax', plugins_url( 'css/mag-post-search-ajax.css', __FILE__ ), array(), self::VERSION );
+		wp_enqueue_style( 'mag-post-search-ajax', self::url( 'css/mag-post-search-ajax.css' ), array(), self::VERSION );
 		
 	}
 	


### PR DESCRIPTION
With these changes it's possible to use CMB2 FPSA from locations other then the Wordpress Plugins folder. Since I use Composer I want to load it from within my theme's vendor directory. I used CMB2 functions to gather the url which is used to load the resources.

Think it could benefit others as well. 👍